### PR TITLE
fix: correct webhook route default, status cast, and finalized persis…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## [v1.1.1]() - 2026-07-08
+
+### Fixed
+
+* Default webhook route in config (`signhost.webhook.route`) pointed to `laravel-signhost.postback`, which does not exist — the registered route is `laravel-signhost.postback.transaction`. Creating a transaction without an explicit `postbackUrl` threw a `RouteNotFoundException`.
+* `Transaction` model cast `status_code` to `TransactionStatus`, but the actual column is `status`. The enum cast never applied, so `$transaction->status` returned a raw int instead of a `TransactionStatus` instance.
+* `sh_transactions` table was missing `finalized` and `finalized_at` columns. `Transactions::markFinalized()` updated `finalized_at` only, which Eloquent silently discarded (mass-assignment guard drops unknown columns) — transactions were never actually marked finalized.
+
+### Breaking
+
+* New migration adds `finalized` (bool) and `finalized_at` (datetime) columns to `sh_transactions`. Republish and run migrations.
+* `$transaction->status` now returns a `TransactionStatus` enum instance instead of a raw int. Update any code comparing it directly against an integer.
+
 ## [v1.0.0]() - 2026-01-09
 
 * Initial release

--- a/config/signhost.php
+++ b/config/signhost.php
@@ -19,7 +19,7 @@ return [
      * Webhook configuration.
      */
     'webhook' => [
-        'route' => env('SIGNHOST_WEBHOOK_ROUTE', 'laravel-signhost.postback'),
+        'route' => env('SIGNHOST_WEBHOOK_ROUTE', 'laravel-signhost.postback.transaction'),
         'secret' => env('SIGNHOST_WEBHOOK_SECRET'),
         'token' => env('SIGNHOST_WEBHOOK_TOKEN'),
     ],

--- a/database/migrations/update_sh_transactions_table_add_finalized.php
+++ b/database/migrations/update_sh_transactions_table_add_finalized.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('sh_transactions', function (Blueprint $table) {
+            $table->boolean('finalized')->default(false)->after('webhook_response');
+            $table->dateTime('finalized_at')->nullable()->after('finalized');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('sh_transactions', function (Blueprint $table) {
+            $table->dropColumn(['finalized', 'finalized_at']);
+        });
+    }
+};

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -29,7 +29,7 @@ class Transaction extends Model
 
     protected $casts = [
         'object' => 'encrypted:object',
-        'status_code' => TransactionStatus::class,
+        'status' => TransactionStatus::class,
         'finalized' => 'boolean',
         'context' => 'encrypted:object',
         'webhook_response' => 'encrypted:object',

--- a/src/Providers/SignhostServiceProvider.php
+++ b/src/Providers/SignhostServiceProvider.php
@@ -24,6 +24,7 @@ class SignhostServiceProvider extends ServiceProvider
         'create_sh_transaction_file_links_table.php',
         'create_sh_transaction_receivers_table.php',
         'create_sh_transaction_activities_table.php',
+        'update_sh_transactions_table_add_finalized.php',
     ];
 
     /**

--- a/src/Repositories/Transactions.php
+++ b/src/Repositories/Transactions.php
@@ -110,10 +110,13 @@ class Transactions
     }
 
     /**
-     * Mark the transaction as finalized (set finalized_at timestamp).
+     * Mark the transaction as finalized.
      */
     public function markFinalized(Transaction $transaction): void
     {
-        $transaction->update(['finalized_at' => Carbon::now()]);
+        $transaction->update([
+            'finalized' => true,
+            'finalized_at' => Carbon::now(),
+        ]);
     }
 }

--- a/tests/Unit/Models/TransactionTest.php
+++ b/tests/Unit/Models/TransactionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Noardcode\LaravelSignhost\Tests\Unit\Models;
+
+use Noardcode\LaravelSignhost\Enums\TransactionStatus;
+use Noardcode\LaravelSignhost\Models\Transaction;
+use Noardcode\LaravelSignhost\Tests\TestCase;
+
+class TransactionTest extends TestCase
+{
+    public function test_status_column_is_cast_to_transaction_status_enum()
+    {
+        $transaction = Transaction::factory()->create(['status' => TransactionStatus::Signed->value]);
+
+        $this->assertInstanceOf(TransactionStatus::class, $transaction->fresh()->status);
+        $this->assertSame(TransactionStatus::Signed, $transaction->fresh()->status);
+    }
+}

--- a/tests/Unit/Repositories/TransactionsTest.php
+++ b/tests/Unit/Repositories/TransactionsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Noardcode\LaravelSignhost\Tests\Unit\Repositories;
+
+use Noardcode\LaravelSignhost\Models\Transaction;
+use Noardcode\LaravelSignhost\Repositories\Transactions;
+use Noardcode\LaravelSignhost\Tests\TestCase;
+
+class TransactionsTest extends TestCase
+{
+    public function test_mark_finalized_persists_finalized_flag_and_timestamp()
+    {
+        $transaction = Transaction::factory()->create([
+            'finalized' => false,
+            'finalized_at' => null,
+        ]);
+
+        app(Transactions::class)->markFinalized($transaction);
+
+        $fresh = $transaction->fresh();
+
+        $this->assertTrue($fresh->finalized);
+        $this->assertNotNull($fresh->finalized_at);
+    }
+}

--- a/tests/Unit/ValueObjects/TransactionTest.php
+++ b/tests/Unit/ValueObjects/TransactionTest.php
@@ -57,4 +57,20 @@ class TransactionTest extends TestCase
             'Context' => '{"key": "value"}',
         ], $transaction->toArray());
     }
+
+    public function test_default_postback_url_resolves_to_registered_route()
+    {
+        $transaction = new Transaction(
+            Language::Dutch,
+            false,
+            new TransactionSignersCollection([]),
+            new TransactionReceiversCollection([]),
+            '1234567890',
+        );
+
+        $this->assertSame(
+            route('laravel-signhost.postback.transaction'),
+            $transaction->getPostbackUrl()
+        );
+    }
 }


### PR DESCRIPTION
- config default `laravel-signhost.postback` route doesn't exist; the registered route is `laravel-signhost.postback.transaction`, so transactions created without an explicit postbackUrl threw RouteNotFoundException.
- Transaction model cast `status_code` (no such column) instead of `status`, so the TransactionStatus enum cast silently never applied.
- sh_transactions was missing finalized/finalized_at columns, so markFinalized() silently no-op'd via Eloquent's mass-assignment guard.

Bumps to v1.1.1 (breaking: new columns + status now casts to an enum instance instead of a raw int). Release notes in CHANGELOG.md.